### PR TITLE
Add the packaging metadata to build the hoard snap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,5 +41,30 @@ archive:
   - README*
   - changelog*
   - CHANGELOG*
+snapcraft:
+  summary: stateless, deterministically encrypted, content-addressed object store
+  description: |
+    It is stateless in the sense of relying on storage backends for the actual
+    persistence of objects. Currently supported backends are:
+
+    * Memory
+    * Filesystem
+    * S3
+
+    Planned storage backends are:
+
+    * IPFS
+    * BigchainDB (and IPDB)
+    * Tendermint
+
+  grade: devel
+  confinement: strict
+
+  apps:
+    hoard:
+      plugs: [home, network, network-bind]
+    hoarctl:
+      plugs: [home, network]
+
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}


### PR DESCRIPTION
This package will let you publish the latest hoard in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://dashboard.snapcraft.io and register your snap there.

You can find more info here: https://goreleaser.com/#snapcraft