### PR TITLE
IPFS Integration

### DIFF
--- a/cmd/hoard/main.go
+++ b/cmd/hoard/main.go
@@ -131,6 +131,14 @@ func main() {
 					}
 				})
 
+			configCmd.Command("ipfs", "Emit initial config with IPFS storage "+
+				"backend.",
+				func(c *cli.Cmd) {
+					c.Action = func() {
+						conf.Storage = storage.DefaultIPFSConfig()
+					}
+				})
+
 			configCmd.Command("existing", "Emit existing config (useful for checking "+
 				"config source or converting format)",
 				func(c *cli.Cmd) {

--- a/config/storage/ipfs.go
+++ b/config/storage/ipfs.go
@@ -1,4 +1,27 @@
 package storage
 
 type IPFSConfig struct {
+	Protocol string
+	Address  string
+	Port     string
+}
+
+func NewIPFSConfig(addressEncoding, proto, address, port string) *StorageConfig {
+	return &StorageConfig{
+		StorageType:     IPFS,
+		AddressEncoding: addressEncoding,
+		IPFSConfig: &IPFSConfig{
+			Protocol: proto,
+			Address:  address,
+			Port:     port,
+		},
+	}
+}
+
+func DefaultIPFSConfig() *StorageConfig {
+	return NewIPFSConfig(DefaultAddressEncodingName,
+		"https://",
+		"127.0.0.1",
+		"5001",
+	)
 }

--- a/config/storage/storage.go
+++ b/config/storage/storage.go
@@ -69,6 +69,24 @@ func StoreFromStorageConfig(storageConfig *StorageConfig,
 				"filesystem storage config")
 		}
 		return storage.NewFileSystemStore(fsc.RootDirectory, addressEncoding)
+	case IPFS:
+		ipfsc := storageConfig.IPFSConfig
+		if ipfsc == nil {
+			return nil, errors.New("IPFS storage configuration must be " +
+				"supplied to use the filesystem storage backend")
+		}
+		if ipfsc.Protocol == "" {
+			ipfsc.Protocol = "https://"
+		}
+		if ipfsc.Address == "" {
+			return nil, errors.New("http api url must be non-empty in " +
+				"ipfs storage config")
+		}
+		if ipfsc.Port == "" {
+			return nil, errors.New("http api port must be non-empty in " +
+				"ipfs storage config")
+		}
+		return storage.NewIPFSStore(ipfsc.Protocol, ipfsc.Address, ipfsc.Port, addressEncoding)
 	case S3:
 		s3c := storageConfig.S3Config
 		if s3c == nil {

--- a/core/storage/filesystem.go
+++ b/core/storage/filesystem.go
@@ -24,8 +24,8 @@ func NewFileSystemStore(rootDirectory string, addressEncoding AddressEncoding) (
 	}, nil
 }
 
-func (fss *fileSystemStore) Put(address *[]byte, data []byte) error {
-	return ioutil.WriteFile(fss.Path(*address), data, 0644)
+func (fss *fileSystemStore) Put(address []byte, data []byte) ([]byte, error) {
+	return address, ioutil.WriteFile(fss.Path(address), data, 0644)
 }
 
 func (fss *fileSystemStore) Get(address []byte) ([]byte, error) {

--- a/core/storage/filesystem.go
+++ b/core/storage/filesystem.go
@@ -24,8 +24,8 @@ func NewFileSystemStore(rootDirectory string, addressEncoding AddressEncoding) (
 	}, nil
 }
 
-func (fss *fileSystemStore) Put(address, data []byte) error {
-	return ioutil.WriteFile(fss.Path(address), data, 0644)
+func (fss *fileSystemStore) Put(address *[]byte, data []byte) error {
+	return ioutil.WriteFile(fss.Path(*address), data, 0644)
 }
 
 func (fss *fileSystemStore) Get(address []byte) ([]byte, error) {

--- a/core/storage/ipfs.go
+++ b/core/storage/ipfs.go
@@ -1,0 +1,119 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+)
+
+type ipfsStore struct {
+	Protocol        string
+	Address         string
+	Port            string
+	addressEncoding AddressEncoding
+}
+
+func NewIPFSStore(proto, address, port string, addressEncoding AddressEncoding) (*ipfsStore, error) {
+	if proto == "http://" {
+		fmt.Println("Warning: IPFS connection not secure.")
+	}
+	_, err := http.Get(proto + address + ":" + port + "/api/v0/")
+	if err != nil {
+		return nil, err
+	}
+	return &ipfsStore{
+		Protocol:        proto,
+		Address:         address,
+		Port:            port,
+		addressEncoding: addressEncoding,
+	}, nil
+}
+
+func (ipfss *ipfsStore) Put(address *[]byte, data []byte) error {
+	uri := ipfss.Protocol + ipfss.Address + ":" + ipfss.Port + "/api/v0/add"
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+
+	fw, err := w.CreateFormField("arg")
+	if _, err = fw.Write((data)[:]); err != nil {
+		return nil
+	}
+	w.Close()
+
+	req, err := http.NewRequest("POST", uri, &b)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body := &bytes.Buffer{}
+	_, err = body.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+	var m map[string]interface{}
+	json.Unmarshal(body.Bytes(), &m)
+
+	// TODO deterministically generate IPFS addresses natively
+	// currently, we `add` the blob and read the return address
+	*address = []byte(m["Name"].(string))
+	return nil
+}
+
+func (ipfss *ipfsStore) Get(address []byte) ([]byte, error) {
+	resp, err := http.Get(ipfss.Protocol + ipfss.Address + ":" + ipfss.Port + "/api/v0/cat?arg=" + string(address))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func (ipfss *ipfsStore) Stat(address []byte) (*StatInfo, error) {
+	resp, err := http.Get(ipfss.Protocol + ipfss.Address + ":" + ipfss.Port + "/api/v0/cat?arg=" + string(address[:]))
+	if err != nil || resp.StatusCode != 200 {
+		return &StatInfo{
+			Exists: false,
+		}, nil
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StatInfo{
+		Exists: true,
+		Size:   uint64(len(body)),
+	}, nil
+}
+
+func (ipfss *ipfsStore) Location(address []byte) string {
+	return string(address)
+}
+
+func (ipfss *ipfsStore) Name() string {
+	return fmt.Sprintf("ipfsStore[api=%s:%s]", ipfss.Address, ipfss.Port)
+}
+
+func (ipfss *ipfsStore) decode(address string) []byte {
+	add, err := ipfss.addressEncoding.DecodeString(address)
+	if err != nil {
+		return nil
+	}
+	return add
+}

--- a/core/storage/ipfs.go
+++ b/core/storage/ipfs.go
@@ -109,11 +109,3 @@ func (ipfss *ipfsStore) Location(address []byte) string {
 func (ipfss *ipfsStore) Name() string {
 	return fmt.Sprintf("ipfsStore[api=%s:%s]", ipfss.Address, ipfss.Port)
 }
-
-func (ipfss *ipfsStore) decode(address string) []byte {
-	add, err := ipfss.addressEncoding.DecodeString(address)
-	if err != nil {
-		return nil
-	}
-	return add
-}

--- a/core/storage/logging_store.go
+++ b/core/storage/logging_store.go
@@ -26,10 +26,10 @@ func NewLoggingStore(store NamedStore, logger log.Logger) *loggingStore {
 
 var _ NamedStore = (*loggingStore)(nil)
 
-func (ls *loggingStore) Put(address *[]byte, data []byte) error {
-	err := ls.store.Put(address, data)
-	return logErrorOrSuccess(log.With(ls.logger, "method", "Put", "address",
-		formatAddress(*address)), err)
+func (ls *loggingStore) Put(address []byte, data []byte) ([]byte, error) {
+	address, err := ls.store.Put(address, data)
+	return address, logErrorOrSuccess(log.With(ls.logger, "method", "Put", "address",
+		formatAddress(address)), err)
 }
 
 func (ls *loggingStore) Get(address []byte) ([]byte, error) {

--- a/core/storage/logging_store.go
+++ b/core/storage/logging_store.go
@@ -26,9 +26,10 @@ func NewLoggingStore(store NamedStore, logger log.Logger) *loggingStore {
 
 var _ NamedStore = (*loggingStore)(nil)
 
-func (ls *loggingStore) Put(address, data []byte) error {
+func (ls *loggingStore) Put(address *[]byte, data []byte) error {
+	err := ls.store.Put(address, data)
 	return logErrorOrSuccess(log.With(ls.logger, "method", "Put", "address",
-		formatAddress(address)), ls.store.Put(address, data))
+		formatAddress(*address)), err)
 }
 
 func (ls *loggingStore) Get(address []byte) ([]byte, error) {

--- a/core/storage/memory.go
+++ b/core/storage/memory.go
@@ -17,9 +17,9 @@ func NewMemoryStore() *memoryStore {
 	}
 }
 
-func (ms *memoryStore) Put(address, data []byte) error {
+func (ms *memoryStore) Put(address *[]byte, data []byte) error {
 	ms.mtx.Lock()
-	ms.memory[string(address)] = data
+	ms.memory[string(*address)] = data
 	ms.mtx.Unlock()
 	return nil
 }

--- a/core/storage/memory.go
+++ b/core/storage/memory.go
@@ -17,11 +17,11 @@ func NewMemoryStore() *memoryStore {
 	}
 }
 
-func (ms *memoryStore) Put(address *[]byte, data []byte) error {
+func (ms *memoryStore) Put(address []byte, data []byte) ([]byte, error) {
 	ms.mtx.Lock()
-	ms.memory[string(*address)] = data
+	ms.memory[string(address)] = data
 	ms.mtx.Unlock()
-	return nil
+	return address, nil
 }
 
 func (ms *memoryStore) Get(address []byte) ([]byte, error) {

--- a/core/storage/s3.go
+++ b/core/storage/s3.go
@@ -63,11 +63,11 @@ func Session(awsConfig *aws.Config) (*session.Session, error) {
 	})
 }
 
-func (s3s *s3Store) Put(address, data []byte) error {
+func (s3s *s3Store) Put(address *[]byte, data []byte) error {
 	// Should be threadsafe
 	output, err := s3s.awsUploader.Upload(&s3manager.UploadInput{
 		Bucket: &s3s.s3Bucket,
-		Key:    aws.String(s3s.Key(address)),
+		Key:    aws.String(s3s.Key(*address)),
 		Body:   bytes.NewReader(data),
 	})
 	if err != nil {
@@ -75,7 +75,7 @@ func (s3s *s3Store) Put(address, data []byte) error {
 	}
 	s3s.logger.Log("method", "Put",
 		"location", output.Location,
-		"encoded_address", s3s.encode(address),
+		"encoded_address", s3s.encode(*address),
 		"version_id", output.VersionID,
 		"upload_id", output.UploadID)
 	return err

--- a/core/storage/s3.go
+++ b/core/storage/s3.go
@@ -63,22 +63,22 @@ func Session(awsConfig *aws.Config) (*session.Session, error) {
 	})
 }
 
-func (s3s *s3Store) Put(address *[]byte, data []byte) error {
+func (s3s *s3Store) Put(address []byte, data []byte) ([]byte, error) {
 	// Should be threadsafe
 	output, err := s3s.awsUploader.Upload(&s3manager.UploadInput{
 		Bucket: &s3s.s3Bucket,
-		Key:    aws.String(s3s.Key(*address)),
+		Key:    aws.String(s3s.Key(address)),
 		Body:   bytes.NewReader(data),
 	})
 	if err != nil {
-		return err
+		return address, err
 	}
 	s3s.logger.Log("method", "Put",
 		"location", output.Location,
-		"encoded_address", s3s.encode(*address),
+		"encoded_address", s3s.encode(address),
 		"version_id", output.VersionID,
 		"upload_id", output.UploadID)
-	return err
+	return address, err
 }
 
 func (s3s *s3Store) Get(address []byte) ([]byte, error) {

--- a/core/storage/storage.go
+++ b/core/storage/storage.go
@@ -33,7 +33,7 @@ type ReadStore interface {
 
 type WriteStore interface {
 	// Put data at address
-	Put(address *[]byte, data []byte) error
+	Put(address []byte, data []byte) ([]byte, error)
 }
 
 type Store interface {
@@ -81,7 +81,7 @@ func (cas *contentAddressedStore) Address(data []byte) []byte {
 
 func (cas *contentAddressedStore) Put(data []byte) ([]byte, error) {
 	address := cas.addresser(data)
-	err := cas.store.Put(&address, data)
+	address, err := cas.store.Put(address, data)
 	return address, err
 }
 

--- a/core/storage/storage.go
+++ b/core/storage/storage.go
@@ -33,7 +33,7 @@ type ReadStore interface {
 
 type WriteStore interface {
 	// Put data at address
-	Put(address, data []byte) error
+	Put(address *[]byte, data []byte) error
 }
 
 type Store interface {
@@ -81,7 +81,7 @@ func (cas *contentAddressedStore) Address(data []byte) []byte {
 
 func (cas *contentAddressedStore) Put(data []byte) ([]byte, error) {
 	address := cas.addresser(data)
-	err := cas.store.Put(address, data)
+	err := cas.store.Put(&address, data)
 	return address, err
 }
 

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -62,7 +62,7 @@ func getPutGet(t *testing.T, store Store, address, data []byte) {
 		"an error")
 
 	// Put data at address
-	err = store.Put(&address, data)
+	address, err = store.Put(address, data)
 	assert.NoError(t, err, "Should be able to Put data at address")
 
 	retrieved, err = store.Get(address)

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -62,7 +62,7 @@ func getPutGet(t *testing.T, store Store, address, data []byte) {
 		"an error")
 
 	// Put data at address
-	err = store.Put(address, data)
+	err = store.Put(&address, data)
 	assert.NoError(t, err, "Should be able to Put data at address")
 
 	retrieved, err = store.Get(address)

--- a/core/storage/sync_store.go
+++ b/core/storage/sync_store.go
@@ -45,9 +45,9 @@ func (ss *syncStore) Stat(address []byte) (*StatInfo, error) {
 
 }
 
-func (ss *syncStore) Put(address *[]byte, data []byte) error {
-	ss.mtx.Lock(*address)
-	defer ss.mtx.Unlock(*address)
+func (ss *syncStore) Put(address []byte, data []byte) ([]byte, error) {
+	ss.mtx.Lock(address)
+	defer ss.mtx.Unlock(address)
 	return ss.store.Put(address, data)
 }
 

--- a/core/storage/sync_store.go
+++ b/core/storage/sync_store.go
@@ -45,9 +45,9 @@ func (ss *syncStore) Stat(address []byte) (*StatInfo, error) {
 
 }
 
-func (ss *syncStore) Put(address, data []byte) error {
-	ss.mtx.Lock(address)
-	defer ss.mtx.Unlock(address)
+func (ss *syncStore) Put(address *[]byte, data []byte) error {
+	ss.mtx.Lock(*address)
+	defer ss.mtx.Unlock(*address)
 	return ss.store.Put(address, data)
 }
 


### PR DESCRIPTION
Provides basic integration with a running IPFS daemon's hosted HTTP API (#19). As IPFS provides its own content addressing I've adapted the address field to be updated by the response headers, although in the future we should be able to deterministically generate this ourselves. The PUT method posts the content as multipart/form-data then pins it to the endpoint and the GET method simply fetches based on the supplied address.