### PR TITLE
bump js version and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,7 @@ The encryption is furthermore vulnerable to the same timing and length attacks t
 
 ### Maturity
 
-Hoard is still pre-release and pre-version, there may be breaking changes to the API at any time. Before version tag v1.0.0 changes minor version number changes may break the hoard.proto or hoarctl APIs (e.g. 0.3.4 -> 0.4.0) but patch number changes should leave it intact (e.g. 0.3.4 -> 0.3.5).
-
-The cryptographic libraries used are standard Go libraries (and Go's NACL implementation) so should be of reasonable quality and are widely deployed. The encryption scheme is straight-forward and has an isolated implementation. However there may be bugs in the implementation.
+Hoard is still young, but the API should be mostly stable. The cryptographic libraries used are standard Go libraries (and Go's NACL implementation) so should be of reasonable quality and are widely deployed. The encryption scheme is straight-forward and has an isolated implementation. However there may be bugs in the implementation.
 
 ## Specification
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monax/hoard",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Hoard client library",
   "main": "hoard-js/index.js",
   "scripts": {


### PR DESCRIPTION
Signed-off-by: Gregory Hill <greg.hill@monax.io>

Published a new npm package where `SecretID -> PublicID` and as we're now on `3.0.0` I cut an outdated comment in the readme.